### PR TITLE
Fix Bug: add proxy buffer size and numbers field for ingress http route

### DIFF
--- a/pkg/ram/v1alpha1/types.go
+++ b/pkg/ram/v1alpha1/types.go
@@ -438,6 +438,8 @@ type IngressHTTPRoute struct {
 	RequestBodySizeLimit int               `json:"request_body_size_limit"`
 	Websocket            bool              `json:"websocket"`
 	ProxyBuffer          bool              `json:"proxy_buffer"`
+	ProxyBufferSize      int               `json:"proxy_buffer_size"`
+	ProxyBufferNumbers   int               `json:"proxy_buffer_numbers"`
 	ProxyHeader          map[string]string `json:"proxy_header"`
 	TargetComponent
 }


### PR DESCRIPTION
- 增加这两个字段，为了修复发布网关策略时，这两个字段未被序列化导致的从 rainbond 安装应用报错的问题。